### PR TITLE
Add mask detection messages and remove unused legacy interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ set(msg_files
   msg/KeyPoint.msg
   msg/KeyPointArray.msg
   msg/Feature.msg
+  msg/DetectMask.msg
+  msg/DetectMaskArray.msg
 )
 set(srv_files
   srv/GetHandToTargetCoord.srv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,11 @@ find_package(vision_msgs REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
-  msg/CurrentState.msg
-  msg/CurrentStateArray.msg
-  msg/ObjectPose.msg
-  msg/ObjectPoseArray.msg
-  msg/StringArray.msg
   msg/KeyPoint.msg
   msg/KeyPointArray.msg
   msg/Feature.msg
 )
 set(srv_files
-  srv/RunCtrl.srv
-  srv/ModeCtrl.srv
   srv/GetHandToTargetCoord.srv
   srv/GetHandToTargetTF.srv
   srv/Features.srv

--- a/msg/CurrentState.msg
+++ b/msg/CurrentState.msg
@@ -1,2 +1,0 @@
-string  joint_name
-float64 current_ma

--- a/msg/CurrentStateArray.msg
+++ b/msg/CurrentStateArray.msg
@@ -1,1 +1,0 @@
-CurrentState[] current_state_array

--- a/msg/DetectMask.msg
+++ b/msg/DetectMask.msg
@@ -1,6 +1,8 @@
 # Information about the class and score
 vision_msgs/ObjectHypothesisWithPose[] results
 
+string instance_id        # class is matched with id
+
 # Mask representation
 int32[] pixel_x           # pixel x coordinates of the mask
 int32[] pixel_y           # pixel y coordinates of the mask

--- a/msg/DetectMask.msg
+++ b/msg/DetectMask.msg
@@ -1,0 +1,4 @@
+vision_msgs/LabelInfo info  # instance class and id with header
+int32 pixel_x[]             # pixel x pos
+int32 pixel_y[]             # pixel y pos
+sensor_msgs/Image mask      # for debug

--- a/msg/DetectMask.msg
+++ b/msg/DetectMask.msg
@@ -1,4 +1,7 @@
-vision_msgs/LabelInfo info  # instance class and id with header
-int32[] pixel_x             # pixel x pos
-int32[] pixel_y             # pixel y pos
-sensor_msgs/Image mask      # for debug
+# Information about the class and score
+vision_msgs/ObjectHypothesisWithPose[] results
+
+# Mask representation
+int32[] pixel_x           # pixel x coordinates of the mask
+int32[] pixel_y           # pixel y coordinates of the mask
+sensor_msgs/Image mask    # Optional: for debug/visualization

--- a/msg/DetectMask.msg
+++ b/msg/DetectMask.msg
@@ -1,4 +1,4 @@
 vision_msgs/LabelInfo info  # instance class and id with header
-int32 pixel_x[]             # pixel x pos
-int32 pixel_y[]             # pixel y pos
+int32[] pixel_x             # pixel x pos
+int32[] pixel_y             # pixel y pos
 sensor_msgs/Image mask      # for debug

--- a/msg/DetectMaskArray.msg
+++ b/msg/DetectMaskArray.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-sobits_interfaces/DetectMask[] mask_array    # each of key points
+sobits_interfaces/DetectMask[] masks  # array of masks

--- a/msg/DetectMaskArray.msg
+++ b/msg/DetectMaskArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+sobits_interfaces/DetectMask[] mask_array    # each of key points

--- a/msg/KeyPointArray.msg
+++ b/msg/KeyPointArray.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-KeyPoint[] key_points_array    # each of key points
+sobits_interfaces/KeyPoint[] key_points_array    # each of key points

--- a/msg/ObjectPose.msg
+++ b/msg/ObjectPose.msg
@@ -1,3 +1,0 @@
-string class_name
-geometry_msgs/Pose pose
-int32 detect_id

--- a/msg/ObjectPoseArray.msg
+++ b/msg/ObjectPoseArray.msg
@@ -1,2 +1,0 @@
-std_msgs/Header header
-ObjectPose[] object_poses

--- a/msg/StringArray.msg
+++ b/msg/StringArray.msg
@@ -1,2 +1,0 @@
-std_msgs/Header header
-string[] data

--- a/srv/ModeCtrl.srv
+++ b/srv/ModeCtrl.srv
@@ -1,3 +1,0 @@
-int64 mode
----
-bool response

--- a/srv/RunCtrl.srv
+++ b/srv/RunCtrl.srv
@@ -1,3 +1,0 @@
-bool request
----
-bool response


### PR DESCRIPTION
## Summary
This PR adds mask-related message definitions to `sobits_interfaces` and cleans up several unused legacy messages and services.

## Changes
- Added `msg/DetectMask.msg`
- Added `msg/DetectMaskArray.msg`
- Registered the new mask messages in `CMakeLists.txt`
- Updated `msg/KeyPointArray.msg` to reference `sobits_interfaces/KeyPoint[]`
- Removed unused messages:
  - `msg/CurrentState.msg`
  - `msg/CurrentStateArray.msg`
  - `msg/ObjectPose.msg`
  - `msg/ObjectPoseArray.msg`
  - `msg/StringArray.msg`
- Removed unused services:
  - `srv/RunCtrl.srv`
  - `srv/ModeCtrl.srv`

## New message definitions
### `DetectMask.msg`
- `vision_msgs/ObjectHypothesisWithPose[] results`
- `string instance_id`
- `int32[] pixel_x`
- `int32[] pixel_y`
- `sensor_msgs/Image mask`

### `DetectMaskArray.msg`
- `std_msgs/Header header`
- `sobits_interfaces/DetectMask[] masks`

## Motivation
This change introduces a dedicated interface for segmentation or mask-based detections, while also simplifying the package by removing interfaces that are no longer used.

## Breaking changes
This PR includes interface removals and field changes, so downstream packages may need updates.

- Deleted legacy message/service files listed above
- `KeyPointArray.msg` now explicitly uses `sobits_interfaces/KeyPoint[]`
- New mask array field name is `masks`
- Consumers of object detection metadata should now use `results` and `instance_id` in `DetectMask.msg`