### PR TITLE
feat: add bell detection interfaces for yamnet_ros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(std_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(vision_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 set(msg_files
@@ -47,7 +48,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
   ${action_files}
-  DEPENDENCIES std_msgs geometry_msgs sensor_msgs vision_msgs
+  DEPENDENCIES std_msgs geometry_msgs sensor_msgs vision_msgs builtin_interfaces
 )
 
 install(DIRECTORY mp3 DESTINATION share/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(msg_files
   msg/Feature.msg
   msg/DetectMask.msg
   msg/DetectMaskArray.msg
+  msg/SoundDetection.msg
 )
 set(srv_files
   srv/GetHandToTargetCoord.srv
@@ -39,6 +40,7 @@ set(action_files
   action/MoveWheelRotate.action
   action/VlaRecordState.action
   action/DisplayControl.action
+  action/ListenForSound.action
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/action/ListenForSound.action
+++ b/action/ListenForSound.action
@@ -1,14 +1,14 @@
-# Goal — start listening for a bell/doorbell sound
-float64 timeout_sec     # max seconds to listen; 0 = no timeout
-float32 threshold 0.15  # YAMNet score threshold to trigger; 0 = use node default
+# Goal
+string[] target_labels                  # empty = use the action server's default labels
+builtin_interfaces/Duration timeout     # zero duration = no timeout
 ---
 # Result
-bool    detected        # true if sound was detected before timeout
-string  label           # class name that triggered (e.g. "Doorbell")
-float32 score           # score of the detected class
-float32 elapsed_time    # seconds from goal start to result
+bool detected                         # true if sound was detected before timeout
+string label                          # class name that triggered (e.g. "Doorbell")
+float32 score                         # score of the detected class
+builtin_interfaces/Duration elapsed_time
 ---
-# Feedback — sent every hop (~0.5 s) while listening
-string  current_top_label    # overall top class right now
-float32 current_top_score    # its score
-bool    candidate_detected   # any doorbell-like class above threshold this frame
+# Feedback
+string current_top_label              # overall top class right now
+float32 current_top_score             # its score
+bool candidate_detected               # any target class above threshold this frame

--- a/action/ListenForSound.action
+++ b/action/ListenForSound.action
@@ -1,0 +1,14 @@
+# Goal — start listening for a bell/doorbell sound
+float64 timeout_sec     # max seconds to listen; 0 = no timeout
+float32 threshold 0.15  # YAMNet score threshold to trigger; 0 = use node default
+---
+# Result
+bool    detected        # true if sound was detected before timeout
+string  label           # class name that triggered (e.g. "Doorbell")
+float32 score           # score of the detected class
+float32 elapsed_time    # seconds from goal start to result
+---
+# Feedback — sent every hop (~0.5 s) while listening
+string  current_top_label    # overall top class right now
+float32 current_top_score    # its score
+bool    candidate_detected   # any doorbell-like class above threshold this frame

--- a/msg/SoundDetection.msg
+++ b/msg/SoundDetection.msg
@@ -1,0 +1,5 @@
+std_msgs/Header header
+string label        # best doorbell-like class detected (e.g. "Doorbell", "Bell")
+float32 score       # YAMNet score for that class [0-1]
+string top_label    # overall top class regardless of category (for diagnostics)
+float32 top_score   # overall top score (for diagnostics)

--- a/package.xml
+++ b/package.xml
@@ -24,5 +24,6 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>vision_msgs</depend>
+  <depend>builtin_interfaces</depend>
 
 </package>


### PR DESCRIPTION
日本語で読みたい方は、このPR説明の一番下にある「日本語版 / Japanese Version」を開いてください。

## Summary

This PR adds the ROS 2 interfaces needed for YAMNet-based sound detection.

It introduces:

- `SoundDetection.msg` for publishing sound detection events
- `ListenForSound.action` for waiting until a target sound is detected or a timeout occurs
- CMake registration so both interfaces are generated by `sobits_interfaces`

## Why

The `yamnet_ros` package uses YAMNet to classify sounds from the robot microphone. YAMNet supports many audio classes, so these interfaces are not limited to doorbells only.

The current use case is the Human Robot Interaction Challenge flow in `robocup_dspl_human_robot_interaction_challenge`, where the robot waits for a bell/doorbell sound before continuing. However, the same interface can also be reused for other YAMNet target sounds in future tasks.

For robot behavior integration, we need two ways to use the detection result:

- A topic message for event-style detection, so another package can subscribe and react when a target sound is heard
- An action interface for state-machine logic, so SMACH-style code can wait until a target sound is detected or the timeout finishes

These definitions are placed in `sobits_interfaces` because it is the shared interface package for SOBITS. This gives `yamnet_ros` and behavior packages a common message/action contract instead of each package defining its own custom sound detection types.

## Interface Details

### `SoundDetection.msg`

Used for publishing sound detection events.

Fields:

- `header`: timestamp and frame information
- `label`: detected target sound class, such as `"Doorbell"` or `"Bell"` in the current HRIC use case
- `score`: YAMNet score for the detected target class
- `top_label`: top overall YAMNet class, useful for diagnostics
- `top_score`: score of the top overall YAMNet class

Example use:

- `yamnet_ros` publishes this on `/yamnet_ros/sound_detection`
- behavior code can subscribe to this topic and react when the configured target sound is detected

### `ListenForSound.action`

Used when a robot behavior needs to wait for a target sound.

Goal:

- `timeout_sec`: maximum time to listen; `0` means no timeout
- `threshold`: optional YAMNet score threshold; `0` means use the node default

Result:

- `detected`: whether the target sound was detected before timeout
- `label`: detected class name
- `score`: score of the detected class
- `elapsed_time`: how long the action listened before finishing

Feedback:

- `current_top_label`: current top YAMNet class
- `current_top_score`: score of the current top class
- `candidate_detected`: whether a target class is currently above threshold

## Related Use

This interface supports the sound detection flow used by:

- `yamnet_ros`
  - publishes `/yamnet_ros/sound_detection`
  - provides `/yamnet_ros/listen_for_sound`
  - includes `WaitForBellState` as a reusable SMACH helper for the current bell/doorbell use case

- `robocup_dspl_human_robot_interaction_challenge`
  - uses YAMNet-based sound detection in the Human Robot Interaction Challenge flow
  - currently listens for `/yamnet_ros/sound_detection` in the doorbell waiting state

## Verification

- Checked the diff against `origin/jazzy-devel`
- Confirmed `SoundDetection.msg` and `ListenForSound.action` are registered in `CMakeLists.txt`
- Ran `git diff --check origin/jazzy-devel...HEAD` with no whitespace errors

<details>
<summary>日本語版 / Japanese Version</summary>

## 概要

このPRでは、YAMNetベースの音検出に必要なROS 2インターフェースを追加します。

追加内容:

- `SoundDetection.msg`: 音検出イベントをpublishするためのメッセージ
- `ListenForSound.action`: 対象の音が検出されるまで、またはタイムアウトするまで待つためのアクション
- `sobits_interfaces` でこれらのインターフェースが生成されるようにするためのCMake登録

## 理由

`yamnet_ros` パッケージは、ロボットのマイク入力からYAMNetを使って音を分類します。YAMNetは多くの音クラスに対応しているため、今回追加するインターフェースはドアベル専用ではありません。

現在の主な用途は、`robocup_dspl_human_robot_interaction_challenge` のHuman Robot Interaction Challengeフローです。このフローでは、ロボットがベル音やドアベル音を待ってから次の処理に進みます。ただし、同じインターフェースは今後ほかのYAMNet対象音にも再利用できます。

ロボットの動作統合のために、検出結果を使う方法が2つ必要です。

- トピック用メッセージ: 他のパッケージがsubscribeして、対象音が検出されたときに反応できるようにするため
- アクションインターフェース: SMACHのような状態機械のコードが、対象音の検出またはタイムアウトまで待てるようにするため

これらの定義は、SOBITSの共有インターフェースパッケージである `sobits_interfaces` に置いています。これにより、`yamnet_ros` と行動制御系のパッケージが、独自の音検出メッセージやアクション型を別々に定義せず、共通のメッセージ・アクション契約を使えるようになります。

## インターフェース詳細

### `SoundDetection.msg`

音検出イベントをpublishするために使います。

フィールド:

- `header`: タイムスタンプとフレーム情報
- `label`: 検出された対象音クラス。現在のHRIC用途では `"Doorbell"` や `"Bell"` など
- `score`: 検出された対象クラスに対するYAMNetスコア
- `top_label`: 診断用の、YAMNet全体で最もスコアが高いクラス
- `top_score`: `top_label` のスコア

使用例:

- `yamnet_ros` が `/yamnet_ros/sound_detection` にpublishする
- 行動制御コードがこのトピックをsubscribeし、設定された対象音が検出されたときに反応する

### `ListenForSound.action`

ロボットの動作が対象音を待つ必要があるときに使います。

Goal:

- `timeout_sec`: 最大待機時間。`0` の場合はタイムアウトなし
- `threshold`: 任意のYAMNetスコアしきい値。`0` の場合はノードのデフォルト値を使用

Result:

- `detected`: タイムアウト前に対象音が検出されたかどうか
- `label`: 検出されたクラス名
- `score`: 検出されたクラスのスコア
- `elapsed_time`: アクションが終了するまでに待機した時間

Feedback:

- `current_top_label`: 現在のYAMNet最上位クラス
- `current_top_score`: 現在の最上位クラスのスコア
- `candidate_detected`: 対象クラスが現在しきい値を超えているかどうか

## 関連する使用先

このインターフェースは、以下の音検出フローをサポートします。

- `yamnet_ros`
  - `/yamnet_ros/sound_detection` をpublishする
  - `/yamnet_ros/listen_for_sound` を提供する
  - 現在のベル/ドアベル用途向けに、再利用可能なSMACHヘルパー `WaitForBellState` を含む

- `robocup_dspl_human_robot_interaction_challenge`
  - Human Robot Interaction ChallengeフローでYAMNetベースの音検出を使用する
  - 現在はドアベル待機ステートで `/yamnet_ros/sound_detection` をlistenしている

## 確認内容

- `origin/jazzy-devel` との差分を確認
- `SoundDetection.msg` と `ListenForSound.action` が `CMakeLists.txt` に登録されていることを確認
- `git diff --check origin/jazzy-devel...HEAD` を実行し、空白エラーがないことを確認

</details>
