### PR TITLE
Add Posture and PostureArray message structures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ set(msg_files
   msg/Feature.msg
   msg/DetectMask.msg
   msg/DetectMaskArray.msg
+  msg/Posture.msg
+  msg/PostureArray.msg
 )
 set(srv_files
   srv/GetHandToTargetCoord.srv

--- a/msg/Posture.msg
+++ b/msg/Posture.msg
@@ -1,0 +1,6 @@
+std_msgs/Header header
+string body_posture
+string arm_posture
+string hand_posture
+geometry_msgs/Pose pose
+string id

--- a/msg/PostureArray.msg
+++ b/msg/PostureArray.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-sobits_interfaces/Posture[] postuers
+sobits_interfaces/Posture[] postures

--- a/msg/PostureArray.msg
+++ b/msg/PostureArray.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-sobits_interfaces/Posture[] posture_array
+sobits_interfaces/Posture[] postuers

--- a/msg/PostureArray.msg
+++ b/msg/PostureArray.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+sobits_interfaces/Posture[] posture_array


### PR DESCRIPTION
This pull request adds support for handling posture-related messages in the codebase. Two new message types are introduced—`Posture` and `PostureArray`—and they are registered in the `CMakeLists.txt` configuration to be included in the build process.

**New message definitions:**

* Added `msg/Posture.msg`, which includes fields for header, body, arm, and hand posture descriptions, a pose, and an ID.
* Added `msg/PostureArray.msg`, which contains a header and an array of `Posture` messages.

**Build configuration updates:**

* Registered `Posture.msg` and `PostureArray.msg` in the `msg_files` section of `CMakeLists.txt` to ensure these messages are compiled and available for use.